### PR TITLE
fixed build errors 

### DIFF
--- a/TyMD380tools/applet/Makefile
+++ b/TyMD380tools/applet/Makefile
@@ -116,7 +116,7 @@ base.img:
 	
 merged.img: applet.img base.img   
 	cp ../patches/$(PATCHDIR)/patched.img ./merged.img
-	python merge_$(SRCVERSION).py merged.img applet.img $(MERGEBASE)
+	python2 merge_$(SRCVERSION).py merged.img applet.img $(MERGEBASE)
 
 #patched.bin: proj
 #	"${MAKE}" -C ../patches/$(PATCHDIR) patched.img
@@ -125,7 +125,7 @@ merged.img: applet.img base.img
 #The wrapped file is the one that works with the Windows updater.
 wrapped.bin: merged.img
 	cp ../firmware/RT82_header_rsrc.bin ./RT82_header_rsrc.bin
-	python ../md380_fw.py --wrap merged.img wrapped.bin
+	python2 ../md380_fw.py --wrap merged.img wrapped.bin
 
 experiment.bin: wrapped.bin
 	cp wrapped.bin experiment.bin

--- a/TyMD380tools/firmware/Makefile_orig
+++ b/TyMD380tools/firmware/Makefile_orig
@@ -44,7 +44,7 @@ $(UNWRAPDIR):
 	mkdir -p $@
 
 $(UNWRAPDIR)/%.img: $(BINDIR)/%.bin | $(UNWRAPDIR)
-	python ../md380_fw.py --unwrap $< $@
+	python2 ../md380_fw.py --unwrap $< $@
 
 $(BINDIR)/%.bin: $(DLDIR)/%.zip | $(BINDIR)
 	unzip -p $< "$(FIRMWARE_ZIPPATH)" >$@


### PR DESCRIPTION
fixed build errors with python3 instead of phyton2 using explicit python version on applet/Makefile and firmware/Makefile_orig